### PR TITLE
Avoid "shadowing outer local variable - response"

### DIFF
--- a/lib/async/http/cache/general.rb
+++ b/lib/async/http/cache/general.rb
@@ -100,9 +100,9 @@ module Async
 						end
 					end
 					
-					return Body.wrap(response) do |response, body|
+					return Body.wrap(response) do |the_response, the_body|
 						Console.logger.debug(self) {"Updating cache for #{key}..."}
-						@store.insert(key, request, Response.new(response, body))
+						@store.insert(key, request, Response.new(the_response, the_body))
 					end
 				end
 				


### PR DESCRIPTION
## Description

This PR attempts to avoid two emitted Ruby warnings:

    gems/async-http-cache-0.4.2/lib/async/http/cache/general.rb:103: warning: shadowing outer local variable - response
    gems/async-http-cache-0.4.2/lib/async/http/cache/general.rb:103: warning: shadowing outer local variable - body

### Types of Changes

- Maintenance.

### Testing

