### PR TITLE
CI: Drop 2.5

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -14,10 +14,9 @@ jobs:
           - macos
         
         ruby:
-          - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - "3.0"
         
         experimental: [false]
         env: [""]


### PR DESCRIPTION

## Description

As discussed earlier in #3, this PR drops EOL Ruby 2.5 from CI matrix.

### Types of Changes

- Maintenance.

### Testing

I'll test in CI.