### PR TITLE
Add support for `Ruby 3.3`

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -21,7 +21,7 @@ jobs:
           - macos
         
         ruby:
-          - "3.1"
+          - "3.3"
     
     steps:
     - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.1"
+        ruby-version: "3.3"
         bundler-cache: true
     
     - uses: actions/download-artifact@v3

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.1"
+        ruby-version: "3.3"
         bundler-cache: true
     
     - name: Installing packages

--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -20,9 +20,8 @@ jobs:
           - macos
         
         ruby:
-          - "2.7"
-          - "3.0"
           - "3.1"
+          - "3.3"
     
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,9 +21,8 @@ jobs:
           - macos
         
         ruby:
-          - "2.7"
-          - "3.0"
           - "3.1"
+          - "3.3"
         
         experimental: [false]
         

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 .covered.db
 
 /external
+
+# for easier future development
+vendor/bundle

--- a/async-http-cache.gemspec
+++ b/async-http-cache.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 2.3.0"
 	
-	spec.add_dependency "async-http", "~> 0.56"
+	spec.add_dependency "async-http", ">= 0.65"
 	
 	spec.add_development_dependency "async-rspec", "~> 1.10"
 	spec.add_development_dependency "covered"

--- a/async-http-cache.gemspec
+++ b/async-http-cache.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "async-http", ">= 0.65"
 	
+  spec.add_development_dependency "io-endpoint"
 	spec.add_development_dependency "async-rspec", "~> 1.10"
 	spec.add_development_dependency "covered"
 	spec.add_development_dependency "rspec"

--- a/spec/async/http/cache/server_context.rb
+++ b/spec/async/http/cache/server_context.rb
@@ -23,7 +23,12 @@
 require 'async/http/server'
 require 'async/http/client'
 require 'async/http/endpoint'
-require 'async/io/shared_endpoint'
+
+require 'io/endpoint'
+require 'io/endpoint/host_endpoint'
+require 'io/endpoint/ssl_endpoint'
+require "io/endpoint/bound_endpoint"
+require "io/endpoint/connected_endpoint"
 
 RSpec.shared_context Async::HTTP::Server do
 	include_context Async::RSpec::Reactor
@@ -47,7 +52,7 @@ RSpec.shared_context Async::HTTP::Server do
 	
 	before do
 		# We bind the endpoint before running the server so that we know incoming connections will be accepted:
-		@bound_endpoint = Async::IO::SharedEndpoint.bound(endpoint)
+    @bound_endpoint = IO::Endpoint::BoundEndpoint.bound(endpoint)
 		
 		# I feel a dedicated class might be better than this hack:
 		allow(@bound_endpoint).to receive(:protocol).and_return(endpoint.protocol)


### PR DESCRIPTION
## What this PR does

This PR adds support for `Ruby 3.3`. 

Nowadays `async-http-cache` requires `async-http ~> 0.56` which is good because it is possible to install `async-http 0.65`, version that adds support for `ruby 3.3`. The thing is, `async-http-cache` as it is now, does not pass tests when installing `async-http 0.65.0` and using `Ruby 3.3`, it fails with error: 

```
LoadError:
  cannot load such file -- async/io/shared_endpoint
```

- [`async-http` changelog](https://github.com/socketry/async-http/releases/tag/v0.65.0) 

This is because `async-http 0.65.0` doesn't use `async-io` anymore and started using `io-endpoint` ([See](https://github.com/socketry/async-http/commit/fff99906c13c4cf410a1461216409be64790a4d8)), this PR changes `server_context.rb` to use `io-endpoint` instead of `async-io`.

## Summary

- use `io-endpoint` instead of `async-io`.
- ignore `vendor/bundle` for easier future development.
- constrain `async-http` to be `>= 0.65`.
- add `3.3` to CI workflows (and remove versions previous to 3.1).

All in all this PR allows tests for ruby 3.3 to pass.
**Good to mention, since `async-http` does not support ruby <3.1 anymore, it's clear to say that changes in this PR won't support ruby <3.1 either.**

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->
- Maintenance.

## Tests

- Executed tests locally.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
